### PR TITLE
Angular 4.0, error handling, max file size, multiple components

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .idea/
 codegen/
 npm-debug.log
+*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ lib/
 node_modules/
 .idea/
 codegen/
+npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,5 @@ src
 node_modules
 .idea
 codegen
+.editorconfig
+*.tgz

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Content-Type. The query has a single field called `image`.
 
 `[preview]="false"` - you can disable images preview.
 
+`[maxFileSize]="1048576"` - the maximum file size that will be accepted, in bytes. No default (any size permitted).
+
 #### Custom headers
 
 If you need to send some headers with your request (for example `Authorization` headers), 
@@ -53,9 +55,11 @@ you can use `[headers]` directive like this.
 
 `[dropBoxMessage]="'Drop your images here!'"` - this is a message that is shown in drop area. Default is "**Drop your images here!**".
 
+`[fileTooLargeMessage]="'Image too large!'"` - message that is shown if the user selects/drops an image that exceeds `maxFileSize`. Default is "**An image was too large and was not uploaded. The maximum file size is x KiB.**".
+
 #### Callbacks
 
-`(onFileUploadFinish)="imageUploaded($event)"`. If `[url]` is specified this event is fired when component gets a responce from the server, also in this case event has field `serverResponse` which contains object returned by the server. If `[url]` is not specified it's fired immediately after an image(s) dropped into file-drop zone of choosed in file browser. So what you can do, is not specify `[url]` to handle upload yourself, for exapmple send the image into firebase storage. To get file use `event.file`.
+`(onFileUploadFinish)="imageUploaded($event)"`. If `[url]` is specified this event is fired when component gets a response from the server, also in this case event has field `serverResponse` which contains the status code and response from the server `{status, response}`. If `[url]` is not specified it's fired immediately after an image(s) dropped into file-drop zone of choosed in file browser. So what you can do, is not specify `[url]` to handle upload yourself, for exapmple send the image into firebase storage. To get file use `event.file`.
 
 `(onRemove)="imageRemoved($event)"` - this event is fired when remove button was clicked and the image preview was removed. *Note that this library doesn't handle deletion from server so you should do it yourself*. Event passed as the argument is the exact same object that was passed to the `(imageUploaded)` callback when image was added so you can access `serverResponse` to get a key to delete your image from server.
 

--- a/package.json
+++ b/package.json
@@ -31,14 +31,15 @@
   },
   "homepage": "https://github.com/aberezkin/image-upload#readme",
   "dependencies": {
-    "@angular/common": "^2.4.9",
-    "@angular/core": "^2.4.9",
+    "@angular/common": "^4.0.0",
+    "@angular/core": "^4.0.0",
     "rxjs": "^5.0.0-rc.2"
   },
   "devDependencies": {
-    "@angular/compiler": "^2.4.9",
-    "@angular/compiler-cli": "^2.4.9",
+    "@angular/compiler": "^4.0.0",
+    "@angular/compiler-cli": "^4.0.0",
+    "@angular/language-service": "^4.0.0",
     "@types/core-js": "^0.9.34",
-    "typescript": "2.0.10"
+    "typescript": "2.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,16 +30,19 @@
     "url": "https://github.com/aberezkin/image-upload/issues"
   },
   "homepage": "https://github.com/aberezkin/image-upload#readme",
-  "dependencies": {
-    "@angular/common": "^4.0.0",
-    "@angular/core": "^4.0.0",
+  "peerDependencies": {
+    "@angular/core": "^2.4.9 || ^4.0.0",
+    "@angular/common": "^2.4.9 || ^4.0.0",
     "rxjs": "^5.0.0-rc.2"
   },
   "devDependencies": {
+    "@angular/core": "^4.0.0",
+    "@angular/common": "^4.0.0",
     "@angular/compiler": "^4.0.0",
     "@angular/compiler-cli": "^4.0.0",
     "@angular/language-service": "^4.0.0",
     "@types/core-js": "^0.9.34",
+    "rxjs": "^5.0.0-rc.2",
     "typescript": "2.1.5"
   }
 }

--- a/src/file-drop.directive.ts
+++ b/src/file-drop.directive.ts
@@ -12,7 +12,7 @@ export class FileDropDirective {
   fileDrop: EventEmitter<FileList> = new EventEmitter<FileList>();
 
   @HostListener('dragover', ['$event'])
-  public onDragOver(event: any) {
+  onDragOver(event: any) {
     let dataTransfer = FileDropDirective.getDataTransfer(event);
 
     if (!FileDropDirective.hasFiles(dataTransfer.types)) {
@@ -25,12 +25,12 @@ export class FileDropDirective {
   }
 
   @HostListener('dragleave', ['$event'])
-  public onDragLeave() {
+  onDragLeave() {
     this.isFileOver.emit(false);
   }
 
   @HostListener('drop', ['$event'])
-  public onDrop(event: any) {
+  onDrop(event: any) {
     let dataTransfer = FileDropDirective.getDataTransfer(event);
 
     if (!FileDropDirective.hasFiles(dataTransfer.types)) {
@@ -52,7 +52,7 @@ export class FileDropDirective {
     }
 
     let acceptedFiles: File[] = [];
-    for(let i = 0; i < files.length; i++) {
+    for (let i = 0; i < files.length; i++) {
       for (let j = 0; j < this.accept.length; j++) {
         if (FileDropDirective.matchRule(this.accept[j], files[i].type)) {
           acceptedFiles.push(files[i]);
@@ -72,7 +72,7 @@ export class FileDropDirective {
     return event.dataTransfer ? event.dataTransfer : event.originalEvent.dataTransfer;
   }
 
-  private static hasFiles(types: any):boolean {
+  private static hasFiles(types: any): boolean {
     if (!types) {
       return false;
     }
@@ -87,6 +87,4 @@ export class FileDropDirective {
 
     return false;
   }
-
-
 }

--- a/src/image-upload/image-upload.component.css
+++ b/src/image-upload/image-upload.component.css
@@ -1,13 +1,15 @@
 .image-upload {
-  --active-color: #30bf5a;
+  --common-radius: 3px;
+  --active-color: #33CC99;
   position: relative;
-  border-radius: 5px;
-  border: #d0d0d0 dotted 2px;
+  border-radius: var(--common-radius);
+  border: #d0d0d0 dashed 1px;
   font-family: sans-serif;
 }
 
 .file-is-over {
-  border: var(--active-color) solid 2px;
+  border-color: var(--active-color);
+  border-style: solid;
 }
 
 .hr-inline-group:after {
@@ -17,20 +19,20 @@
 }
 
 .file-upload {
-  padding: 15px;
-  background-color: #f3f3f3;
+  padding: 16px;
+  background-color: #f8f8f8;
 }
 
 .drag-box-message {
   float: left;
   display: inline-block;
-  margin-left: 10px;
-  padding-top: 8px;
+  margin-left: 12px;
+  padding-top: 14px;
   color: #9b9b9b;
   font-weight: 600;
 }
 
-label.upload-button input[type=file]{
+label.upload-button input[type=file] {
   display: none;
   position: fixed;
   top: -99999px;
@@ -39,26 +41,34 @@ label.upload-button input[type=file]{
 .upload-button {
   cursor: pointer;
   background-color: var(--active-color);
-  padding: 5px 10px 5px 10px;
-  border-radius: 5px;
+  padding: 10px;
   color: white;
   font-size: 1.25em;
-  font-weight: 600;
+  font-weight: 500;
   text-transform: uppercase;
   display: inline-block;
   float: left;
+
+  -webkit-box-shadow: 2px 2px 4px 0px rgba(148,148,148,0.6);
+  -moz-box-shadow: 2px 2px 4px 0px rgba(148,148,148,0.6);
+  box-shadow: 2px 2px 4px 0px rgba(148,148,148,0.6);
 }
 
+.upload-button:active span{
+  position: relative;
+  display: block;
+  top: 1px;
+}
 
 .image-container {
-  background-color: #f8f8f8;
-  border-radius: 0 0 5px 5px;
+  background-color: #fdfdfd;
+  padding: 0 10px 0 10px;
 }
 
 .image {
   float: left;
   display: inline-block;
-  margin: 5px;
+  margin: 6px;
   width: 86px;
   height: 86px;
   background: center center no-repeat;
@@ -94,7 +104,7 @@ label.upload-button input[type=file]{
   position: absolute;
   content: '';
   height: 16px;
-  width: 3px;
+  width: 2px;
   top: 2px;
   background-color: #FFFFFF;
 }

--- a/src/image-upload/image-upload.component.css
+++ b/src/image-upload/image-upload.component.css
@@ -49,12 +49,12 @@ label.upload-button input[type=file] {
   display: inline-block;
   float: left;
 
-  -webkit-box-shadow: 2px 2px 4px 0px rgba(148,148,148,0.6);
-  -moz-box-shadow: 2px 2px 4px 0px rgba(148,148,148,0.6);
-  box-shadow: 2px 2px 4px 0px rgba(148,148,148,0.6);
+  -webkit-box-shadow: 2px 2px 4px 0px rgba(148, 148, 148, 0.6);
+  -moz-box-shadow: 2px 2px 4px 0px rgba(148, 148, 148, 0.6);
+  box-shadow: 2px 2px 4px 0px rgba(148, 148, 148, 0.6);
 }
 
-.upload-button:active span{
+.upload-button:active span {
   position: relative;
   display: block;
   top: 1px;
@@ -96,9 +96,11 @@ label.upload-button input[type=file] {
   position: relative;
   padding-right: 3px;
 }
+
 .x-mark:hover .close {
   opacity: 1;
 }
+
 .close:before, .close:after {
   border-radius: 2px;
   position: absolute;
@@ -119,7 +121,10 @@ label.upload-button input[type=file] {
 
 .loading-overlay {
   position: absolute;
-  top: 0; left: 0; bottom: 0; right: 0;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
   background-color: black;
   opacity: .7;
 }
@@ -129,13 +134,21 @@ label.upload-button input[type=file] {
   width: 30px;
   margin: auto;
   position: absolute;
-  top: 0; left: 0; bottom: 0; right: 0;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
   border-radius: 50%;
   border: 3px solid rgba(255, 255, 255, 0);
   border-top: 3px solid white;
   border-right: 3px solid white;
   -webkit-animation: spinner 2s infinite cubic-bezier(0.085, 0.625, 0.855, 0.360);
   animation: spinner 2s infinite cubic-bezier(0.085, 0.625, 0.855, 0.360);
+}
+
+.file-too-large {
+  color: red;
+  padding: 0 15px;
 }
 
 @-webkit-keyframes spinner {

--- a/src/image-upload/image-upload.component.html
+++ b/src/image-upload/image-upload.component.html
@@ -9,20 +9,23 @@
     <label class="upload-button">
       <span [innerText]="buttonCaption"></span>
       <input
-              type="file"
-              accept="image/*"
-              multiple (change)="fileChange(input.files)"
-              #input>
+        type="file"
+        accept="image/*"
+        multiple (change)="fileChange(input.files)"
+        #input>
     </label>
 
     <div class="drag-box-message" [innerText]="dropBoxMessage"></div>
   </div>
 
+  <p class="file-too-large" *ngIf="showFileTooLargeMessage" [innerText]="fileTooLargeMessage">
+  </p>
+
   <div *ngIf="preview" class="image-container hr-inline-group">
     <div
-            class="image"
-            *ngFor="let file of files"
-            [ngStyle]="{'background-image': 'url('+ file.src +')'}"
+      class="image"
+      *ngFor="let file of files"
+      [ngStyle]="{'background-image': 'url('+ file.src +')'}"
     >
       <div *ngIf="file.pending" class="loading-overlay">
         <div class="spinningCircle"></div>

--- a/src/image-upload/image-upload.component.html
+++ b/src/image-upload/image-upload.component.html
@@ -7,22 +7,22 @@
 >
   <div class="file-upload hr-inline-group">
     <label class="upload-button">
-      <span>{{buttonMessage}}</span>
+      <span [innerText]="buttonCaption"></span>
       <input
-        type="file"
-        accept="image/*"
-        multiple (change)="fileChange(input.files)"
-        #input>
+              type="file"
+              accept="image/*"
+              multiple (change)="fileChange(input.files)"
+              #input>
     </label>
 
-    <div class="drag-box-message">{{dragBoxMessage}}</div>
+    <div class="drag-box-message" [innerText]="dropBoxMessage"></div>
   </div>
 
-  <div class="image-container hr-inline-group">
+  <div *ngIf="preview" class="image-container hr-inline-group">
     <div
-      class="image"
-      *ngFor="let file of files"
-      [ngStyle]="{'background-image': 'url('+ file.src +')'}"
+            class="image"
+            *ngFor="let file of files"
+            [ngStyle]="{'background-image': 'url('+ file.src +')'}"
     >
       <div *ngIf="file.pending" class="loading-overlay">
         <div class="spinningCircle"></div>

--- a/src/image-upload/image-upload.component.ts
+++ b/src/image-upload/image-upload.component.ts
@@ -1,5 +1,5 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {ImageService, Header} from "../image.service";
+import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {Header, ImageService} from '../image.service';
 
 export class FileHolder {
   public serverResponse: { status: number, response: any };
@@ -12,214 +12,222 @@ export class FileHolder {
 @Component({
   selector: 'image-upload',
   template: `
-  <div class="image-upload"
-     fileDrop
-     [accept]="['image/*']"
-     (isFileOver)="fileOver($event)"
-     (fileDrop)="fileChange($event)"
-     [ngClass]="{'file-is-over': isFileOver}"
->
-  <div class="file-upload hr-inline-group">
-    <label class="upload-button">
-      <span [innerText]="buttonCaption"></span>
-      <input
-        type="file"
-        accept="image/*"
-        multiple (change)="fileChange(input.files)"
-        #input>
-    </label>
-
-    <div class="drag-box-message" [innerText]="dropBoxMessage"></div>
-  </div>
-  
-  <p class="file-too-large" *ngIf="showFileTooLargeMessage" [innerText]="fileTooLargeMessage">
-  </p>
-
-  <div *ngIf="preview" class="image-container hr-inline-group">
-    <div
-      class="image"
-      *ngFor="let file of files"
-      [ngStyle]="{'background-image': 'url('+ file.src +')'}"
+    <div class="image-upload"
+         fileDrop
+         [accept]="['image/*']"
+         (isFileOver)="fileOver($event)"
+         (fileDrop)="fileChange($event)"
+         [ngClass]="{'file-is-over': isFileOver}"
     >
-      <div *ngIf="file.pending" class="loading-overlay">
-        <div class="spinningCircle"></div>
+      <div class="file-upload hr-inline-group">
+        <label class="upload-button">
+          <span [innerText]="buttonCaption"></span>
+          <input
+            type="file"
+            accept="image/*"
+            multiple (change)="fileChange(input.files)"
+            #input>
+        </label>
+
+        <div class="drag-box-message" [innerText]="dropBoxMessage"></div>
       </div>
-      <div *ngIf="!file.pending" class="x-mark" (click)="deleteFile(file)">
-        <span class="close"></span>
+
+      <p class="file-too-large" *ngIf="showFileTooLargeMessage" [innerText]="fileTooLargeMessage">
+      </p>
+
+      <div *ngIf="preview" class="image-container hr-inline-group">
+        <div
+          class="image"
+          *ngFor="let file of files"
+          [ngStyle]="{'background-image': 'url('+ file.src +')'}"
+        >
+          <div *ngIf="file.pending" class="loading-overlay">
+            <div class="spinningCircle"></div>
+          </div>
+          <div *ngIf="!file.pending" class="x-mark" (click)="deleteFile(file)">
+            <span class="close"></span>
+          </div>
+        </div>
       </div>
-    </div>
-  </div>
-</div>`,
+    </div>`,
   styles: [`
-.image-upload {
-  --common-radius: 3px;
-  --active-color: #33CC99;
-  position: relative;
-  border-radius: var(--common-radius);
-  border: #d0d0d0 dashed 1px;
-  font-family: sans-serif;
-}
+    .image-upload {
+      --common-radius: 3px;
+      --active-color: #33CC99;
+      position: relative;
+      border-radius: var(--common-radius);
+      border: #d0d0d0 dashed 1px;
+      font-family: sans-serif;
+    }
 
-.file-is-over {
-  border-color: var(--active-color);
-  border-style: solid;
-}
+    .file-is-over {
+      border-color: var(--active-color);
+      border-style: solid;
+    }
 
-.hr-inline-group:after {
-  display: table;
-  clear: both;
-  content: "";
-}
+    .hr-inline-group:after {
+      display: table;
+      clear: both;
+      content: "";
+    }
 
-.file-upload {
-  padding: 16px;
-  background-color: #f8f8f8;
-}
+    .file-upload {
+      padding: 16px;
+      background-color: #f8f8f8;
+    }
 
-.drag-box-message {
-  float: left;
-  display: inline-block;
-  margin-left: 12px;
-  padding-top: 14px;
-  color: #9b9b9b;
-  font-weight: 600;
-}
+    .drag-box-message {
+      float: left;
+      display: inline-block;
+      margin-left: 12px;
+      padding-top: 14px;
+      color: #9b9b9b;
+      font-weight: 600;
+    }
 
-label.upload-button input[type=file] {
-  display: none;
-  position: fixed;
-  top: -99999px;
-}
+    label.upload-button input[type=file] {
+      display: none;
+      position: fixed;
+      top: -99999px;
+    }
 
-.upload-button {
-  cursor: pointer;
-  background-color: var(--active-color);
-  padding: 10px;
-  color: white;
-  font-size: 1.25em;
-  font-weight: 500;
-  text-transform: uppercase;
-  display: inline-block;
-  float: left;
-  
-  -webkit-box-shadow: 2px 2px 4px 0px rgba(148,148,148,0.6);
-  -moz-box-shadow: 2px 2px 4px 0px rgba(148,148,148,0.6);
-  box-shadow: 2px 2px 4px 0px rgba(148,148,148,0.6);
-}
+    .upload-button {
+      cursor: pointer;
+      background-color: var(--active-color);
+      padding: 10px;
+      color: white;
+      font-size: 1.25em;
+      font-weight: 500;
+      text-transform: uppercase;
+      display: inline-block;
+      float: left;
 
-.upload-button:active span{
-  position: relative;
-  display: block;
-  top: 1px;
-}
+      -webkit-box-shadow: 2px 2px 4px 0px rgba(148, 148, 148, 0.6);
+      -moz-box-shadow: 2px 2px 4px 0px rgba(148, 148, 148, 0.6);
+      box-shadow: 2px 2px 4px 0px rgba(148, 148, 148, 0.6);
+    }
 
-.image-container {
-  background-color: #fdfdfd;
-  padding: 0 10px 0 10px;
-}
+    .upload-button:active span {
+      position: relative;
+      display: block;
+      top: 1px;
+    }
 
-.image {
-  float: left;
-  display: inline-block;
-  margin: 6px;
-  width: 86px;
-  height: 86px;
-  background: center center no-repeat;
-  background-size: contain;
-  position: relative;
-}
+    .image-container {
+      background-color: #fdfdfd;
+      padding: 0 10px 0 10px;
+    }
 
-.x-mark {
-  width: 20px;
-  height: 20px;
-  text-align: center;
-  cursor: pointer;
-  border-radius: 2px;
-  float: right;
-  background-color: black;
-  opacity: .7;
-  color: white;
-  margin: 2px;
-}
+    .image {
+      float: left;
+      display: inline-block;
+      margin: 6px;
+      width: 86px;
+      height: 86px;
+      background: center center no-repeat;
+      background-size: contain;
+      position: relative;
+    }
 
-.close {
-  width: 20px;
-  height: 20px;
-  opacity: .7;
-  position: relative;
-  padding-right: 3px;
-}
-.x-mark:hover .close {
-  opacity: 1;
-}
-.close:before, .close:after {
-  border-radius: 2px;
-  position: absolute;
-  content: '';
-  height: 16px;
-  width: 2px;
-  top: 2px;
-  background-color: #FFFFFF;
-}
+    .x-mark {
+      width: 20px;
+      height: 20px;
+      text-align: center;
+      cursor: pointer;
+      border-radius: 2px;
+      float: right;
+      background-color: black;
+      opacity: .7;
+      color: white;
+      margin: 2px;
+    }
 
-.close:before {
-  transform: rotate(45deg);
-}
+    .close {
+      width: 20px;
+      height: 20px;
+      opacity: .7;
+      position: relative;
+      padding-right: 3px;
+    }
 
-.close:after {
-  transform: rotate(-45deg);
-}
+    .x-mark:hover .close {
+      opacity: 1;
+    }
 
-.loading-overlay {
-  position: absolute;
-  top: 0; left: 0; bottom: 0; right: 0;
-  background-color: black;
-  opacity: .7;
-}
+    .close:before, .close:after {
+      border-radius: 2px;
+      position: absolute;
+      content: '';
+      height: 16px;
+      width: 2px;
+      top: 2px;
+      background-color: #FFFFFF;
+    }
 
-.spinningCircle {
-  height: 30px;
-  width: 30px;
-  margin: auto;
-  position: absolute;
-  top: 0; left: 0; bottom: 0; right: 0;
-  border-radius: 50%;
-  border: 3px solid rgba(255, 255, 255, 0);
-  border-top: 3px solid white;
-  border-right: 3px solid white;
-  -webkit-animation: spinner 2s infinite cubic-bezier(0.085, 0.625, 0.855, 0.360);
-  animation: spinner 2s infinite cubic-bezier(0.085, 0.625, 0.855, 0.360);
-}
+    .close:before {
+      transform: rotate(45deg);
+    }
 
-.file-too-large {
-  color: red;
-  padding: 0 15px;
-}
+    .close:after {
+      transform: rotate(-45deg);
+    }
 
-@-webkit-keyframes spinner {
-  0% {
-    -webkit-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-  100% {
-    -webkit-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
-}
+    .loading-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      right: 0;
+      background-color: black;
+      opacity: .7;
+    }
 
-@keyframes spinner {
-  0% {
-    -webkit-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-  100% {
-    -webkit-transform: rotate(360deg);
-    transform: rotate(360deg);
+    .spinningCircle {
+      height: 30px;
+      width: 30px;
+      margin: auto;
+      position: absolute;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      right: 0;
+      border-radius: 50%;
+      border: 3px solid rgba(255, 255, 255, 0);
+      border-top: 3px solid white;
+      border-right: 3px solid white;
+      -webkit-animation: spinner 2s infinite cubic-bezier(0.085, 0.625, 0.855, 0.360);
+      animation: spinner 2s infinite cubic-bezier(0.085, 0.625, 0.855, 0.360);
+    }
 
-  }
-}`]
+    .file-too-large {
+      color: red;
+      padding: 0 15px;
+    }
+
+    @-webkit-keyframes spinner {
+      0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+      }
+      100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+      }
+    }
+
+    @keyframes spinner {
+      0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+      }
+      100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+
+      }
+    }`]
 })
-export class ImageUploadComponent {
+export class ImageUploadComponent implements OnInit {
   @Input() max: number = 100;
   @Input() url: string;
   @Input() headers: Header[];
@@ -252,8 +260,6 @@ export class ImageUploadComponent {
   }
 
   ngOnInit() {
-    this.imageService.setUrl(this.url);
-
     if (!this.fileTooLargeMessage) {
       this.fileTooLargeMessage = 'An image was too large and was not uploaded.' + (this.maxFileSize ? (' The maximum file size is ' + this.maxFileSize / 1024) + 'KiB.' : '');
     }
@@ -328,7 +334,7 @@ export class ImageUploadComponent {
       fileHolder.pending = true;
 
       this.imageService
-        .postImage(fileHolder.file, this.headers)
+        .postImage(this.url, fileHolder.file, this.headers)
         .subscribe(
           response => this.onResponse(response, fileHolder),
           error => {

--- a/src/image-upload/image-upload.component.ts
+++ b/src/image-upload/image-upload.component.ts
@@ -239,7 +239,7 @@ export class ImageUploadComponent {
   private fileCounter: number = 0;
   private pendingFilesCounter: number = 0;
 
-  private isFileOver: boolean = false;
+  isFileOver: boolean = false;
 
   @Input()
   buttonCaption: string = "Select Images";

--- a/src/image.service.ts
+++ b/src/image.service.ts
@@ -25,14 +25,13 @@ export class ImageService {
       xhr.onreadystatechange = () => {
         if (xhr.readyState === 4) {
           if (xhr.status === 200) {
-            observer.next(xhr.response);
+            observer.next({response: xhr.response, status: xhr.status});
             observer.complete();
           } else {
-            observer.error(xhr.response);
+            observer.error({response: xhr.response, status: xhr.status});
           }
         }
       };
-
 
       xhr.open('POST', this.url, true);
 
@@ -49,5 +48,4 @@ export class ImageService {
       throw new Error('Url is not set! Please use setUrl(url) method before doing queries');
     }
   }
-
 }

--- a/src/image.service.ts
+++ b/src/image.service.ts
@@ -8,14 +8,11 @@ export interface Header {
 
 @Injectable()
 export class ImageService {
-  private url: string;
+  public postImage(url: string, image: File, headers?: Header[]) {
+    if (!url || url === '') {
+      throw new Error('Url is not set! Please set it before doing queries');
+    }
 
-  public setUrl(url: string) {
-    this.url = url;
-  }
-
-  public postImage(image: File, headers?: Header[]) {
-    this.checkUrl();
     return Observable.create(observer => {
       let formData: FormData = new FormData();
       let xhr: XMLHttpRequest = new XMLHttpRequest();
@@ -33,7 +30,7 @@ export class ImageService {
         }
       };
 
-      xhr.open('POST', this.url, true);
+      xhr.open('POST', url, true);
 
       if (headers)
         for (let header of headers)
@@ -41,11 +38,5 @@ export class ImageService {
 
       xhr.send(formData);
     });
-  }
-
-  private checkUrl() {
-    if (!this.url) {
-      throw new Error('Url is not set! Please use setUrl(url) method before doing queries');
-    }
   }
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,7 +3,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "moduleResolution": "node",
-    "target": "es6",
+    "target": "es5",
     "module": "commonjs",
     "removeComments": true,
     "sourceMap": true,
@@ -11,6 +11,10 @@
     "declaration": true,
     "typeRoots": [
       "../node_modules/@types"
+    ],
+    "lib": [
+      "es2016",
+      "dom"
     ]
   },
   "angularCompilerOptions": {

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,7 +3,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "moduleResolution": "node",
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "removeComments": true,
     "sourceMap": true,


### PR DESCRIPTION
Service now returns a response object, which includes the status code.
Handle upload errors and emit them through the onFileUploadFinish event.
Updated stylesheet with changes from inline styles.
Updated HTML with changes from inline HTML.
Added some inputs to allow the implementing application to specify a maximum file size.

Use case for error handling change:
My server has a file size limit of 2MB, if a file over this size is posted it will respond with 400 BAD REQUEST, the library should emit the onFileUploadFinish event in this case, and allow the implementing application to handle the error.

This was tested with a fresh @angular/cli 1.0.0 project with @angular 4.0.0