### PR TITLE
Fix for issue with ng build -prod

### DIFF
--- a/src/file-drop.directive.ts
+++ b/src/file-drop.directive.ts
@@ -25,7 +25,7 @@ export class FileDropDirective {
   }
 
   @HostListener('dragleave', ['$event'])
-  onDragLeave() {
+  onDragLeave(event) {
     this.isFileOver.emit(false);
   }
 


### PR DESCRIPTION
Error in /../../$$_gendir/node_modules/angular2-image-upload/lib/file-drop.directive.ngfactory.ts (51,35): Supplied parameters do not match any signature of call target.

This error occurs when I run ng build -prod