### PR TITLE
fix: using custom url (if present) instead of initialized value

### DIFF
--- a/src/image-upload/image-upload.component.ts
+++ b/src/image-upload/image-upload.component.ts
@@ -168,7 +168,7 @@ export class ImageUploadComponent implements OnInit, OnChanges {
       fileHolder.pending = true;
 
       this.imageService
-        .postImage(this.url, fileHolder.file, this.headers, this.partName, customForm, this.withCredentials)
+        .postImage(url, fileHolder.file, this.headers, this.partName, customForm, this.withCredentials)
         .subscribe(
           response => this.onResponse(response, fileHolder),
           error => {


### PR DESCRIPTION
`uploadSingleFile` takes the target URL for an image in as a parameter, defaulting it to `this.url`. However, when actually uploading the file, it uses `this.url` instead of just `url`. This means that any custom url set by a call to beforeUpload isn't used