### PR TITLE
fix: delete image error (#208)

### DIFF
--- a/src/image-upload/image-upload.component.ts
+++ b/src/image-upload/image-upload.component.ts
@@ -65,14 +65,18 @@ export class ImageUploadComponent implements OnInit, OnChanges {
     this.files.forEach(f => this.removed.emit(f));
     this.files = [];
     this.fileCounter = 0;
-    this.inputElement.nativeElement.value = '';
+    if (this.inputElement) {
+      this.inputElement.nativeElement.value = '';
+    }
   }
 
   deleteFile(file: FileHolder): void {
     let index = this.files.indexOf(file);
     this.files.splice(index, 1);
     this.fileCounter--;
-    this.inputElement.nativeElement.value = '';
+    if (this.inputElement) {
+      this.inputElement.nativeElement.value = '';
+    }
     this.removed.emit(file);
   }
 


### PR DESCRIPTION
This PR resolves issue #208 .
The `inputElement` will not be rendered if the max file count is reached.
`<label *ngIf="fileCounter != max">`
If user clears the images after upload, the line 
`this.inputElement.nativeElement.value = '';`
will throw error.
I am checking if `inputElement` exists before clearing its values