### PR TITLE
update for the case when maxFileSize Error occured

### DIFF
--- a/src/image-upload/image-upload.component.ts
+++ b/src/image-upload/image-upload.component.ts
@@ -150,6 +150,7 @@ export class ImageUploadComponent implements OnInit, OnChanges {
         this.fileCounter--;
         this.inputElement.nativeElement.value = '';
         this.showFileTooLargeMessage = true;
+        this.uploadStateChanged.emit(false)
         continue;
       }
 


### PR DESCRIPTION
when you upload oversize image at the end of files, 
you got no emit event of uploadStateChanged. 
You should get emit event 'false' because it's not pending...

I disabled my image-uploader when I got uploadStateChanged = true, 
but when I get maxFileSize error, it doesn't comeback enabled, because is didn't get 'false' uploadStateChange event.